### PR TITLE
Add list exporters

### DIFF
--- a/ZWebAPI/Exporters/ColumnMetadataResolver.cs
+++ b/ZWebAPI/Exporters/ColumnMetadataResolver.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace ZWebAPI.Exporters
+{
+    /// <summary>
+    /// Resolves <see cref="ExportColumn"/> metadata for a row type by reflecting its public
+    /// readable instance properties. Honors <see cref="ExportColumnAttribute"/> overrides
+    /// (custom header, ignore, order, type) and caches the result per type.
+    /// </summary>
+    public static class ColumnMetadataResolver
+    {
+        #region Variables
+        private static readonly ConcurrentDictionary<Type, IReadOnlyList<ExportColumn>> Cache = new();
+        #endregion
+
+        #region Public methods
+        /// <summary>
+        /// Resolves columns for <paramref name="rowType"/>.
+        /// </summary>
+        public static IReadOnlyList<ExportColumn> Resolve(Type rowType)
+        {
+            ArgumentNullException.ThrowIfNull(rowType);
+
+            return Cache.GetOrAdd(rowType, BuildColumns);
+        }
+        #endregion
+
+        #region Private methods
+        private static IReadOnlyList<ExportColumn> BuildColumns(Type rowType)
+        {
+            PropertyInfo[] properties = rowType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+            List<(int DeclarationOrder, int ExplicitOrder, ExportColumn Column)> buffer = new();
+
+            for (int i = 0; i < properties.Length; i++)
+            {
+                PropertyInfo property = properties[i];
+                if (!property.CanRead)
+                {
+                    continue;
+                }
+
+                ExportColumnAttribute? attribute = property.GetCustomAttribute<ExportColumnAttribute>();
+                if (attribute?.Ignore == true)
+                {
+                    continue;
+                }
+
+                string header = string.IsNullOrWhiteSpace(attribute?.Header) ? property.Name : attribute!.Header!;
+                ExportColumnType type = attribute?.Type ?? ExportColumnType.Text;
+
+                Func<object, object?> selector = (row) => property.GetValue(row);
+
+                buffer.Add((i, attribute?.Order ?? int.MaxValue, new ExportColumn(header, type, selector)));
+            }
+
+            return buffer
+                .OrderBy(x => x.ExplicitOrder)
+                .ThenBy(x => x.DeclarationOrder)
+                .Select(x => x.Column)
+                .ToList();
+        }
+        #endregion
+    }
+}

--- a/ZWebAPI/Exporters/Exceptions/ExportRowLimitExceededException.cs
+++ b/ZWebAPI/Exporters/Exceptions/ExportRowLimitExceededException.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace ZWebAPI.Exporters.Exceptions
+{
+    /// <summary>
+    /// Thrown when a list export request would exceed <see cref="ExportConstants.MaxExportRows"/>.
+    /// Controllers map this exception to HTTP 413 Payload Too Large.
+    /// </summary>
+    public sealed class ExportRowLimitExceededException : Exception
+    {
+        #region Properties
+        /// <summary>The configured row limit.</summary>
+        public int MaxRows { get; }
+        #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExportRowLimitExceededException"/> class.
+        /// </summary>
+        /// <param name="maxRows">The configured row limit.</param>
+        public ExportRowLimitExceededException(int maxRows)
+            : base($"The export result exceeds the configured limit of {maxRows} rows.")
+        {
+            MaxRows = maxRows;
+        }
+        #endregion
+    }
+}

--- a/ZWebAPI/Exporters/ExportColumn.cs
+++ b/ZWebAPI/Exporters/ExportColumn.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace ZWebAPI.Exporters
+{
+    /// <summary>
+    /// Metadata for a single column in an exported list.
+    /// </summary>
+    public sealed class ExportColumn
+    {
+        #region Properties
+        /// <summary>
+        /// Column header text displayed in the exported file.
+        /// </summary>
+        public string Header { get; }
+
+        /// <summary>
+        /// Format type for type-aware exporters (Excel, PDF).
+        /// </summary>
+        public ExportColumnType Type { get; }
+
+        /// <summary>
+        /// Selector extracting the column value from a row instance.
+        /// </summary>
+        public Func<object, object?> ValueSelector { get; }
+        #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExportColumn"/> class.
+        /// </summary>
+        /// <param name="header">Column header text (already translated if applicable).</param>
+        /// <param name="type">Format type for type-aware exporters.</param>
+        /// <param name="valueSelector">Selector extracting the column value from a row instance.</param>
+        public ExportColumn(string header, ExportColumnType type, Func<object, object?> valueSelector)
+        {
+            Header = header;
+            Type = type;
+            ValueSelector = valueSelector;
+        }
+        #endregion
+    }
+}

--- a/ZWebAPI/Exporters/ExportColumnAttribute.cs
+++ b/ZWebAPI/Exporters/ExportColumnAttribute.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace ZWebAPI.Exporters
+{
+    /// <summary>
+    /// Optional attribute overriding default export behavior for a list-model property.
+    /// By default every public readable property is exported using the property name as the header.
+    /// Apply this attribute only to change the header, skip the property, or specify a format type.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public sealed class ExportColumnAttribute : Attribute
+    {
+        #region Properties
+        /// <summary>
+        /// Optional header/i18n key. When <c>null</c>, the property name is used.
+        /// </summary>
+        public string? Header { get; set; }
+
+        /// <summary>
+        /// When <c>true</c>, the property is skipped entirely from exports.
+        /// </summary>
+        public bool Ignore { get; set; }
+
+        /// <summary>
+        /// Column ordinal when multiple columns need explicit ordering. Lower values appear first.
+        /// Properties without an order preserve their declaration order.
+        /// </summary>
+        public int Order { get; set; } = int.MaxValue;
+
+        /// <summary>
+        /// Format type for type-aware exporters (Excel, PDF). Defaults to <see cref="ExportColumnType.Text"/>.
+        /// </summary>
+        public ExportColumnType Type { get; set; } = ExportColumnType.Text;
+        #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExportColumnAttribute"/> class.
+        /// </summary>
+        public ExportColumnAttribute()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExportColumnAttribute"/> class with a custom header.
+        /// </summary>
+        /// <param name="header">The header (or i18n key) to display instead of the property name.</param>
+        public ExportColumnAttribute(string header)
+        {
+            Header = header;
+        }
+        #endregion
+    }
+}

--- a/ZWebAPI/Exporters/ExportColumnType.cs
+++ b/ZWebAPI/Exporters/ExportColumnType.cs
@@ -1,0 +1,26 @@
+namespace ZWebAPI.Exporters
+{
+    /// <summary>
+    /// Describes how an exported column value should be formatted.
+    /// </summary>
+    public enum ExportColumnType
+    {
+        /// <summary>Raw text.</summary>
+        Text = 0,
+
+        /// <summary>Integer or decimal number.</summary>
+        Number = 1,
+
+        /// <summary>Date (no time component).</summary>
+        Date = 2,
+
+        /// <summary>Date and time.</summary>
+        DateTime = 3,
+
+        /// <summary>Currency amount.</summary>
+        Currency = 4,
+
+        /// <summary>Boolean.</summary>
+        Boolean = 5,
+    }
+}

--- a/ZWebAPI/Exporters/ExportConstants.cs
+++ b/ZWebAPI/Exporters/ExportConstants.cs
@@ -1,0 +1,14 @@
+namespace ZWebAPI.Exporters
+{
+    /// <summary>
+    /// Shared constants for the list-export feature.
+    /// </summary>
+    public static class ExportConstants
+    {
+        /// <summary>
+        /// Maximum number of rows allowed in a single export request.
+        /// Requests exceeding this throw <see cref="Exceptions.ExportRowLimitExceededException"/>.
+        /// </summary>
+        public const int MaxExportRows = 50_000;
+    }
+}

--- a/ZWebAPI/Exporters/ExportFormat.cs
+++ b/ZWebAPI/Exporters/ExportFormat.cs
@@ -1,0 +1,23 @@
+namespace ZWebAPI.Exporters
+{
+    /// <summary>
+    /// Supported list export formats.
+    /// </summary>
+    public enum ExportFormat
+    {
+        /// <summary>Excel workbook (.xlsx).</summary>
+        Xlsx = 0,
+
+        /// <summary>Comma-separated values (.csv).</summary>
+        Csv = 1,
+
+        /// <summary>Portable Document Format (.pdf).</summary>
+        Pdf = 2,
+
+        /// <summary>XML document (.xml).</summary>
+        Xml = 3,
+
+        /// <summary>Web archive (.mhtml).</summary>
+        Mhtml = 4,
+    }
+}

--- a/ZWebAPI/Exporters/ExportResult.cs
+++ b/ZWebAPI/Exporters/ExportResult.cs
@@ -1,0 +1,34 @@
+namespace ZWebAPI.Exporters
+{
+    /// <summary>
+    /// Result produced by <see cref="IListExporter"/> — a file payload with its MIME metadata.
+    /// </summary>
+    public sealed class ExportResult
+    {
+        #region Properties
+        /// <summary>File bytes.</summary>
+        public byte[] Content { get; }
+
+        /// <summary>MIME content type.</summary>
+        public string ContentType { get; }
+
+        /// <summary>Full file name including extension.</summary>
+        public string FileName { get; }
+        #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExportResult"/> class.
+        /// </summary>
+        /// <param name="content">File bytes.</param>
+        /// <param name="contentType">MIME content type.</param>
+        /// <param name="fileName">Full file name including extension.</param>
+        public ExportResult(byte[] content, string contentType, string fileName)
+        {
+            Content = content;
+            ContentType = contentType;
+            FileName = fileName;
+        }
+        #endregion
+    }
+}

--- a/ZWebAPI/Exporters/ExportValueFormatter.cs
+++ b/ZWebAPI/Exporters/ExportValueFormatter.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Globalization;
+
+namespace ZWebAPI.Exporters
+{
+    /// <summary>
+    /// Formats column values into their exported string representation for text-based formats.
+    /// Type-aware exporters (Excel) may bypass this and write native types directly.
+    /// </summary>
+    public static class ExportValueFormatter
+    {
+        #region Variables
+        /// <summary>
+        /// Culture used for all formatting. Uses pt-BR because the application targets Brazilian
+        /// users — decimals as <c>1.234,56</c> and dates as <c>dd/MM/yyyy</c>.
+        /// </summary>
+        public static readonly CultureInfo Culture = new("pt-BR");
+        #endregion
+
+        #region Public methods
+        /// <summary>
+        /// Converts <paramref name="value"/> into its exported string representation.
+        /// </summary>
+        public static string Format(object? value, ExportColumnType type)
+        {
+            if (value is null)
+            {
+                return string.Empty;
+            }
+
+            return type switch
+            {
+                ExportColumnType.Date => value is DateTime dt ? dt.ToString("dd/MM/yyyy", Culture) : value.ToString() ?? string.Empty,
+                ExportColumnType.DateTime => value is DateTime dtm ? dtm.ToString("dd/MM/yyyy HH:mm", Culture) : value.ToString() ?? string.Empty,
+                ExportColumnType.Currency => value is IFormattable fmt1 ? fmt1.ToString("C2", Culture) : value.ToString() ?? string.Empty,
+                ExportColumnType.Number => value is IFormattable fmt2 ? fmt2.ToString("N2", Culture) : value.ToString() ?? string.Empty,
+                ExportColumnType.Boolean => value is bool b ? (b ? "Sim" : "Não") : value.ToString() ?? string.Empty,
+                _ => value.ToString() ?? string.Empty,
+            };
+        }
+        #endregion
+    }
+}

--- a/ZWebAPI/Exporters/Formats/CsvExporter.cs
+++ b/ZWebAPI/Exporters/Formats/CsvExporter.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace ZWebAPI.Exporters.Formats
+{
+    /// <summary>
+    /// RFC 4180 CSV exporter. Writes a UTF-8 BOM so Excel opens the file with correct encoding.
+    /// </summary>
+    internal sealed class CsvExporter
+    {
+        #region Public methods
+        public ExportResult Export(IEnumerable<object> rows, IReadOnlyList<ExportColumn> columns, string fileBaseName)
+        {
+            StringBuilder builder = new();
+
+            for (int i = 0; i < columns.Count; i++)
+            {
+                if (i > 0)
+                {
+                    builder.Append(',');
+                }
+                builder.Append(Escape(columns[i].Header));
+            }
+            builder.Append("\r\n");
+
+            foreach (object row in rows)
+            {
+                for (int i = 0; i < columns.Count; i++)
+                {
+                    if (i > 0)
+                    {
+                        builder.Append(',');
+                    }
+                    object? raw = columns[i].ValueSelector(row);
+                    string formatted = ExportValueFormatter.Format(raw, columns[i].Type);
+                    builder.Append(Escape(formatted));
+                }
+                builder.Append("\r\n");
+            }
+
+            byte[] bom = Encoding.UTF8.GetPreamble();
+            byte[] body = Encoding.UTF8.GetBytes(builder.ToString());
+            byte[] content = new byte[bom.Length + body.Length];
+            Buffer.BlockCopy(bom, 0, content, 0, bom.Length);
+            Buffer.BlockCopy(body, 0, content, bom.Length, body.Length);
+
+            return new ExportResult(content, "text/csv; charset=utf-8", $"{fileBaseName}.csv");
+        }
+        #endregion
+
+        #region Private methods
+        private static string Escape(string value)
+        {
+            if (value.IndexOfAny([',', '"', '\r', '\n']) < 0)
+            {
+                return value;
+            }
+            return "\"" + value.Replace("\"", "\"\"") + "\"";
+        }
+        #endregion
+    }
+}

--- a/ZWebAPI/Exporters/Formats/MhtmlExporter.cs
+++ b/ZWebAPI/Exporters/Formats/MhtmlExporter.cs
@@ -1,0 +1,107 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+
+namespace ZWebAPI.Exporters.Formats
+{
+    /// <summary>
+    /// Web-archive (.mhtml) exporter. Renders an HTML table and wraps it in a
+    /// <c>multipart/related</c> MIME envelope so browsers open the file as a saved web page.
+    /// </summary>
+    internal sealed class MhtmlExporter
+    {
+        #region Variables
+        private const string Boundary = "----=_NextPart_ZWebAPI_Export";
+        #endregion
+
+        #region Public methods
+        public ExportResult Export(IEnumerable<object> rows, IReadOnlyList<ExportColumn> columns, string fileBaseName)
+        {
+            string html = BuildHtml(rows, columns);
+            string encodedHtml = QuotedPrintableEncode(html);
+
+            StringBuilder mime = new();
+            mime.Append("MIME-Version: 1.0\r\n");
+            mime.Append($"Content-Type: multipart/related; boundary=\"{Boundary}\"\r\n");
+            mime.Append("\r\n");
+            mime.Append($"--{Boundary}\r\n");
+            mime.Append("Content-Type: text/html; charset=\"utf-8\"\r\n");
+            mime.Append("Content-Transfer-Encoding: quoted-printable\r\n");
+            mime.Append("Content-Location: export.html\r\n");
+            mime.Append("\r\n");
+            mime.Append(encodedHtml);
+            mime.Append("\r\n");
+            mime.Append($"--{Boundary}--\r\n");
+
+            byte[] content = Encoding.UTF8.GetBytes(mime.ToString());
+            return new ExportResult(content, "message/rfc822", $"{fileBaseName}.mhtml");
+        }
+        #endregion
+
+        #region Private methods
+        private static string BuildHtml(IEnumerable<object> rows, IReadOnlyList<ExportColumn> columns)
+        {
+            StringBuilder html = new();
+            html.Append("<!DOCTYPE html><html><head><meta charset=\"utf-8\"><style>");
+            html.Append("body{font-family:Arial,sans-serif;font-size:12px;}");
+            html.Append("table{border-collapse:collapse;width:100%;}");
+            html.Append("th,td{border:1px solid #888;padding:4px 8px;text-align:left;}");
+            html.Append("th{background:#e0e0e0;}");
+            html.Append("tr:nth-child(even) td{background:#f7f7f7;}");
+            html.Append("</style></head><body><table><thead><tr>");
+
+            foreach (ExportColumn column in columns)
+            {
+                html.Append("<th>").Append(WebUtility.HtmlEncode(column.Header)).Append("</th>");
+            }
+            html.Append("</tr></thead><tbody>");
+
+            foreach (object row in rows)
+            {
+                html.Append("<tr>");
+                for (int i = 0; i < columns.Count; i++)
+                {
+                    object? raw = columns[i].ValueSelector(row);
+                    string formatted = ExportValueFormatter.Format(raw, columns[i].Type);
+                    html.Append("<td>").Append(WebUtility.HtmlEncode(formatted)).Append("</td>");
+                }
+                html.Append("</tr>");
+            }
+
+            html.Append("</tbody></table></body></html>");
+            return html.ToString();
+        }
+
+        private static string QuotedPrintableEncode(string input)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(input);
+            StringBuilder result = new();
+            int lineLength = 0;
+
+            foreach (byte b in bytes)
+            {
+                bool needsEncoding = b == (byte)'=' || b < 32 || b > 126;
+                if (b == (byte)'\r' || b == (byte)'\n')
+                {
+                    result.Append((char)b);
+                    lineLength = 0;
+                    continue;
+                }
+
+                string chunk = needsEncoding ? $"={b:X2}" : ((char)b).ToString();
+
+                if (lineLength + chunk.Length > 75)
+                {
+                    result.Append("=\r\n");
+                    lineLength = 0;
+                }
+
+                result.Append(chunk);
+                lineLength += chunk.Length;
+            }
+
+            return result.ToString();
+        }
+        #endregion
+    }
+}

--- a/ZWebAPI/Exporters/Formats/PdfExporter.cs
+++ b/ZWebAPI/Exporters/Formats/PdfExporter.cs
@@ -1,0 +1,84 @@
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+using System.Collections.Generic;
+
+namespace ZWebAPI.Exporters.Formats
+{
+    /// <summary>
+    /// PDF exporter using QuestPDF. Produces a landscape A4 document with a repeating header row,
+    /// auto-sized columns, and alternating row shading for readability.
+    /// </summary>
+    internal sealed class PdfExporter
+    {
+        #region Constructors
+        /// <summary>
+        /// Configures the QuestPDF license once per process. Runs on first load of <see cref="PdfExporter"/>,
+        /// which covers every code path that actually renders a PDF (services, tests, and the WebApi host).
+        /// </summary>
+        static PdfExporter()
+        {
+            QuestPDF.Settings.License = LicenseType.Community;
+        }
+        #endregion
+
+        #region Public methods
+        public ExportResult Export(IEnumerable<object> rows, IReadOnlyList<ExportColumn> columns, string fileBaseName)
+        {
+            byte[] bytes = Document.Create(container =>
+            {
+                container.Page(page =>
+                {
+                    page.Size(PageSizes.A4.Landscape());
+                    page.Margin(20);
+                    page.DefaultTextStyle(x => x.FontSize(9));
+
+                    page.Content().Table(table =>
+                    {
+                        table.ColumnsDefinition(cd =>
+                        {
+                            for (int i = 0; i < columns.Count; i++)
+                            {
+                                cd.RelativeColumn();
+                            }
+                        });
+
+                        table.Header(header =>
+                        {
+                            foreach (ExportColumn column in columns)
+                            {
+                                header.Cell().Background(Colors.Grey.Lighten2)
+                                    .Padding(4)
+                                    .Text(column.Header)
+                                    .Bold();
+                            }
+                        });
+
+                        int rowIndex = 0;
+                        foreach (object row in rows)
+                        {
+                            string background = rowIndex % 2 == 0 ? Colors.White : Colors.Grey.Lighten4;
+                            for (int c = 0; c < columns.Count; c++)
+                            {
+                                object? raw = columns[c].ValueSelector(row);
+                                string formatted = ExportValueFormatter.Format(raw, columns[c].Type);
+                                table.Cell().Background(background).Padding(4).Text(formatted);
+                            }
+                            rowIndex++;
+                        }
+                    });
+
+                    page.Footer().AlignRight().Text(x =>
+                    {
+                        x.CurrentPageNumber();
+                        x.Span(" / ");
+                        x.TotalPages();
+                    });
+                });
+            }).GeneratePdf();
+
+            return new ExportResult(bytes, "application/pdf", $"{fileBaseName}.pdf");
+        }
+        #endregion
+    }
+}

--- a/ZWebAPI/Exporters/Formats/XlsxExporter.cs
+++ b/ZWebAPI/Exporters/Formats/XlsxExporter.cs
@@ -1,0 +1,127 @@
+using ClosedXML.Excel;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace ZWebAPI.Exporters.Formats
+{
+    /// <summary>
+    /// Excel (.xlsx) exporter using ClosedXML. Writes type-aware cells so numbers, dates,
+    /// and currencies remain sortable and filterable in Excel; freezes the header row.
+    /// </summary>
+    internal sealed class XlsxExporter
+    {
+        #region Public methods
+        public ExportResult Export(IEnumerable<object> rows, IReadOnlyList<ExportColumn> columns, string fileBaseName)
+        {
+            using XLWorkbook workbook = new();
+            IXLWorksheet sheet = workbook.Worksheets.Add("Export");
+
+            for (int c = 0; c < columns.Count; c++)
+            {
+                IXLCell headerCell = sheet.Cell(1, c + 1);
+                headerCell.Value = columns[c].Header;
+                headerCell.Style.Font.Bold = true;
+            }
+
+            int rowIndex = 2;
+            foreach (object row in rows)
+            {
+                for (int c = 0; c < columns.Count; c++)
+                {
+                    IXLCell cell = sheet.Cell(rowIndex, c + 1);
+                    WriteCell(cell, columns[c].ValueSelector(row), columns[c].Type);
+                }
+                rowIndex++;
+            }
+
+            sheet.SheetView.FreezeRows(1);
+            sheet.Columns().AdjustToContents();
+
+            using MemoryStream stream = new();
+            workbook.SaveAs(stream);
+
+            return new ExportResult(
+                stream.ToArray(),
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                $"{fileBaseName}.xlsx");
+        }
+        #endregion
+
+        #region Private methods
+        private static void WriteCell(IXLCell cell, object? value, ExportColumnType type)
+        {
+            if (value is null)
+            {
+                cell.Value = Blank.Value;
+                return;
+            }
+
+            switch (type)
+            {
+                case ExportColumnType.Date:
+                    if (value is DateTime dt)
+                    {
+                        cell.Value = dt;
+                        cell.Style.DateFormat.Format = "dd/MM/yyyy";
+                    }
+                    else
+                    {
+                        cell.Value = value.ToString();
+                    }
+                    break;
+
+                case ExportColumnType.DateTime:
+                    if (value is DateTime dtm)
+                    {
+                        cell.Value = dtm;
+                        cell.Style.DateFormat.Format = "dd/MM/yyyy HH:mm";
+                    }
+                    else
+                    {
+                        cell.Value = value.ToString();
+                    }
+                    break;
+
+                case ExportColumnType.Currency:
+                    if (value is IConvertible conv1)
+                    {
+                        cell.Value = Convert.ToDecimal(conv1, ExportValueFormatter.Culture);
+                        cell.Style.NumberFormat.Format = "\"R$\" #,##0.00";
+                    }
+                    else
+                    {
+                        cell.Value = value.ToString();
+                    }
+                    break;
+
+                case ExportColumnType.Number:
+                    if (value is IConvertible conv2)
+                    {
+                        cell.Value = Convert.ToDouble(conv2, ExportValueFormatter.Culture);
+                    }
+                    else
+                    {
+                        cell.Value = value.ToString();
+                    }
+                    break;
+
+                case ExportColumnType.Boolean:
+                    if (value is bool b)
+                    {
+                        cell.Value = b ? "Sim" : "Não";
+                    }
+                    else
+                    {
+                        cell.Value = value.ToString();
+                    }
+                    break;
+
+                default:
+                    cell.Value = value.ToString();
+                    break;
+            }
+        }
+        #endregion
+    }
+}

--- a/ZWebAPI/Exporters/Formats/XmlExporter.cs
+++ b/ZWebAPI/Exporters/Formats/XmlExporter.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Xml;
+
+namespace ZWebAPI.Exporters.Formats
+{
+    /// <summary>
+    /// XML exporter. Emits a simple <c>&lt;rows&gt;&lt;row&gt;&lt;column name="..."&gt;value&lt;/column&gt;...&lt;/row&gt;&lt;/rows&gt;</c>
+    /// document using the column headers as attribute values. Columns are emitted under a
+    /// <c>&lt;column&gt;</c> element (rather than as dynamic element names) so any header string
+    /// works without XML naming restrictions.
+    /// </summary>
+    internal sealed class XmlExporter
+    {
+        #region Public methods
+        public ExportResult Export(IEnumerable<object> rows, IReadOnlyList<ExportColumn> columns, string fileBaseName)
+        {
+            using MemoryStream stream = new();
+            XmlWriterSettings settings = new()
+            {
+                Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                Indent = true,
+            };
+
+            using (XmlWriter writer = XmlWriter.Create(stream, settings))
+            {
+                writer.WriteStartDocument();
+                writer.WriteStartElement("rows");
+
+                foreach (object row in rows)
+                {
+                    writer.WriteStartElement("row");
+                    for (int i = 0; i < columns.Count; i++)
+                    {
+                        object? raw = columns[i].ValueSelector(row);
+                        string formatted = ExportValueFormatter.Format(raw, columns[i].Type);
+
+                        writer.WriteStartElement("column");
+                        writer.WriteAttributeString("name", columns[i].Header);
+                        writer.WriteString(formatted);
+                        writer.WriteEndElement();
+                    }
+                    writer.WriteEndElement();
+                }
+
+                writer.WriteEndElement();
+                writer.WriteEndDocument();
+            }
+
+            return new ExportResult(stream.ToArray(), "application/xml; charset=utf-8", $"{fileBaseName}.xml");
+        }
+        #endregion
+    }
+}

--- a/ZWebAPI/Exporters/IListExporter.cs
+++ b/ZWebAPI/Exporters/IListExporter.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+
+namespace ZWebAPI.Exporters
+{
+    /// <summary>
+    /// Generic list exporter — converts a row collection into a file payload for any supported
+    /// <see cref="ExportFormat"/>. Column metadata is either reflected from the row type's
+    /// public properties (optionally annotated with <see cref="ExportColumnAttribute"/>) or
+    /// provided explicitly by the caller.
+    /// </summary>
+    public interface IListExporter
+    {
+        /// <summary>
+        /// Exports <paramref name="rows"/> using columns reflected from <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">Row/model type.</typeparam>
+        /// <param name="rows">Row collection.</param>
+        /// <param name="format">Target format.</param>
+        /// <param name="fileBaseName">File name without extension; the exporter appends the extension.</param>
+        ExportResult Export<T>(IEnumerable<T> rows, ExportFormat format, string fileBaseName);
+
+        /// <summary>
+        /// Exports <paramref name="rows"/> using the explicitly provided <paramref name="columns"/>.
+        /// </summary>
+        /// <param name="rows">Row collection as non-generic objects.</param>
+        /// <param name="columns">Column metadata.</param>
+        /// <param name="format">Target format.</param>
+        /// <param name="fileBaseName">File name without extension; the exporter appends the extension.</param>
+        ExportResult Export(IEnumerable<object> rows, IReadOnlyList<ExportColumn> columns, ExportFormat format, string fileBaseName);
+    }
+}

--- a/ZWebAPI/Exporters/ListExporter.cs
+++ b/ZWebAPI/Exporters/ListExporter.cs
@@ -1,0 +1,51 @@
+using ZWebAPI.Exporters.Formats;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ZWebAPI.Exporters
+{
+    /// <summary>
+    /// Default <see cref="IListExporter"/> implementation. Resolves column metadata via
+    /// <see cref="ColumnMetadataResolver"/> and dispatches to the format-specific exporter.
+    /// </summary>
+    public sealed class ListExporter : IListExporter
+    {
+        #region Variables
+        private readonly CsvExporter csvExporter = new();
+        private readonly MhtmlExporter mhtmlExporter = new();
+        private readonly PdfExporter pdfExporter = new();
+        private readonly XlsxExporter xlsxExporter = new();
+        private readonly XmlExporter xmlExporter = new();
+        #endregion
+
+        #region Public methods
+        /// <inheritdoc />
+        public ExportResult Export<T>(IEnumerable<T> rows, ExportFormat format, string fileBaseName)
+        {
+            IReadOnlyList<ExportColumn> columns = ColumnMetadataResolver.Resolve(typeof(T));
+            return Export(rows.Cast<object>(), columns, format, fileBaseName);
+        }
+
+        /// <inheritdoc />
+        public ExportResult Export(IEnumerable<object> rows, IReadOnlyList<ExportColumn> columns, ExportFormat format, string fileBaseName)
+        {
+            ArgumentNullException.ThrowIfNull(rows);
+            ArgumentNullException.ThrowIfNull(columns);
+            ArgumentException.ThrowIfNullOrWhiteSpace(fileBaseName);
+
+            List<object> materialized = rows.ToList();
+
+            return format switch
+            {
+                ExportFormat.Xlsx => xlsxExporter.Export(materialized, columns, fileBaseName),
+                ExportFormat.Csv => csvExporter.Export(materialized, columns, fileBaseName),
+                ExportFormat.Pdf => pdfExporter.Export(materialized, columns, fileBaseName),
+                ExportFormat.Xml => xmlExporter.Export(materialized, columns, fileBaseName),
+                ExportFormat.Mhtml => mhtmlExporter.Export(materialized, columns, fileBaseName),
+                _ => throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported export format."),
+            };
+        }
+        #endregion
+    }
+}

--- a/ZWebAPI/Exporters/ListResult.cs
+++ b/ZWebAPI/Exporters/ListResult.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ZWebAPI.Exporters
+{
+    /// <summary>
+    /// Envelope returned by list endpoints that opt into the "total rows" contract.
+    /// Carries the paginated <see cref="Items"/> and the <see cref="TotalRows"/> matching
+    /// the current filter (pre-pagination).
+    /// </summary>
+    /// <typeparam name="T">Row model type.</typeparam>
+    public sealed class ListResult<T>
+    {
+        #region Constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ListResult{T}"/> class.
+        /// </summary>
+        /// <param name="items">Paginated items to return.</param>
+        /// <param name="totalRows">Total rows matching the filter before pagination.</param>
+        public ListResult(IEnumerable<T> items, int totalRows)
+        {
+            Items = items;
+            TotalRows = totalRows;
+        }
+        #endregion
+
+        #region Properties
+        /// <summary>Paginated items.</summary>
+        public IEnumerable<T> Items { get; }
+
+        /// <summary>Total rows matching the filter, before pagination.</summary>
+        public int TotalRows { get; }
+        #endregion
+
+        #region Public methods
+        /// <summary>
+        /// Convenience factory that materializes <paramref name="items"/> and captures the total.
+        /// </summary>
+        public static ListResult<T> From(IEnumerable<T> items, int totalRows)
+        {
+            return new ListResult<T>(items is List<T> ? items : items.ToList(), totalRows);
+        }
+        #endregion
+    }
+}

--- a/ZWebAPI/ExtensionMethods/DependencyInjectionExtensions.cs
+++ b/ZWebAPI/ExtensionMethods/DependencyInjectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using ZDatabase.Entities.Audit;
+using ZWebAPI.Exporters;
 using ZWebAPI.Services;
 using ZWebAPI.Services.Interfaces;
 
@@ -26,5 +27,14 @@ namespace ZWebAPI.ExtensionMethods
             where TUsersKey : struct
             => services
                 .AddScoped<IAuditService<TUsers, TUsersKey>, AuditServiceDefault<TServicesHistory, TOperationsHistory, TUsers, TUsersKey>>();
+
+        /// <summary>
+        /// Adds the list exporter service to the service collection.
+        /// </summary>
+        /// <param name="services">The services.</param>
+        /// <returns>The service collection.</returns>
+        public static IServiceCollection AddListExporter(this IServiceCollection services)
+            => services
+                .AddSingleton<IListExporter, ListExporter>();
     }
 }

--- a/ZWebAPI/ZWebAPI.csproj
+++ b/ZWebAPI/ZWebAPI.csproj
@@ -25,6 +25,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoMapper" Version="14.0.0" />
+		<PackageReference Include="ClosedXML" Version="0.104.2" />
+		<PackageReference Include="QuestPDF" Version="2024.12.3" />
 		<PackageReference Include="ZDatabase" Version="1.4.0" />
 		<PackageReference Include="ZSecurity" Version="1.3.0" />
 	</ItemGroup>


### PR DESCRIPTION
## Summary
- Move the System list exporter implementation into ZWebAPI under the ZWebAPI.Exporters namespace.
- Add Csv, MHTML, PDF, XLSX, and XML exporter support with shared column metadata and formatting helpers.
- Add ClosedXML and QuestPDF dependencies, plus AddListExporter() for DI registration.

## Validation
- dotnet build ZWebAPI.sln (passes with existing NU1903 AutoMapper 14.0.0 vulnerability warning).